### PR TITLE
ci: 🤖 don't wait for percy status on branches

### DIFF
--- a/.github/src/workflows/test-and-deploy.yml
+++ b/.github/src/workflows/test-and-deploy.yml
@@ -91,15 +91,26 @@ jobs:
       - name: Increase file watchers to avoid storybook warnings
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
+        # Check if we should run e2e tests & percy review.
+        # If no tests are ran or if we don't take any snapshots,
+        # percy will fail.
+      - name: Should run E2E?
+        id: should-run-e2e
+        run: |
+          # `grep -c` fails if list is empty (no e2e tests to run)
+          SHOULD_RUN_E2E=$(yarn nx print-affected --base=deployed/marmicode-next \
+            | yarn json projects | grep -c e2e && echo true || echo false)
+          echo "::set-output name=should-run-e2e::$SHOULD_RUN_E2E"
+
       # Run all E2E tests on main branch.
       - name: All E2E
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.should-run-e2e.outputs.should-run-e2e != false
         run: npx @percy/cli exec -- $(npm bin)/nx run-many --all --target=e2e --base=deployed/marmicode-next --browser=chrome
 
       # Run affected E2E tests only on other branches.
       # Cf. https://docs.percy.io/docs/partial-builds
       - name: Affected E2E
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && steps.should-run-e2e.outputs.should-run-e2e != false
         run: npx @percy/cli exec -- $(npm bin)/nx affected --target=e2e --base=deployed/marmicode-next --browser=chrome
         env:
           PERCY_PARTIAL_BUILD: 1

--- a/.github/src/workflows/test-and-deploy.yml
+++ b/.github/src/workflows/test-and-deploy.yml
@@ -115,8 +115,10 @@ jobs:
         env:
           PERCY_PARTIAL_BUILD: 1
 
+      # Check Percy Review on main branch only.
+      # On other branches, we'll let Percy status check do the job.
       - name: Check Percy Review
-        if: steps.should-run-e2e.outputs.should-run-e2e != false
+        if: github.ref == 'refs/heads/main' && steps.should-run-e2e.outputs.should-run-e2e != false
         # @hack on PR events, Percy uses the last commit hash instead of the merge commit hash.
         # We have to use PR_HEAD_SHA if present then fallback to GITHUB_SHA.
         run: PERCY_TOKEN=$PERCY_FULL_TOKEN npx @percy/cli build:wait --project marmicode/marmicode --commit "${PR_HEAD_SHA:-$GITHUB_SHA}" --fail-on-changes

--- a/.github/src/workflows/test-and-deploy.yml
+++ b/.github/src/workflows/test-and-deploy.yml
@@ -91,26 +91,15 @@ jobs:
       - name: Increase file watchers to avoid storybook warnings
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-        # Check if we should run e2e tests & percy review.
-        # If no tests are ran or if we don't take any snapshots,
-        # percy will fail.
-      - name: Should run E2E?
-        id: should-run-e2e
-        run: |
-          # `grep -c` fails if list is empty (no e2e tests to run)
-          SHOULD_RUN_E2E=$(yarn nx print-affected --base=deployed/marmicode-next \
-            | yarn json projects | grep -c e2e && echo true || echo false)
-          echo "::set-output name=should-run-e2e::$SHOULD_RUN_E2E"
-
       # Run all E2E tests on main branch.
       - name: All E2E
-        if: github.ref == 'refs/heads/main' && steps.should-run-e2e.outputs.should-run-e2e != false
+        if: github.ref == 'refs/heads/main'
         run: npx @percy/cli exec -- $(npm bin)/nx run-many --all --target=e2e --base=deployed/marmicode-next --browser=chrome
 
       # Run affected E2E tests only on other branches.
       # Cf. https://docs.percy.io/docs/partial-builds
       - name: Affected E2E
-        if: github.ref != 'refs/heads/main' && steps.should-run-e2e.outputs.should-run-e2e != false
+        if: github.ref != 'refs/heads/main'
         run: npx @percy/cli exec -- $(npm bin)/nx affected --target=e2e --base=deployed/marmicode-next --browser=chrome
         env:
           PERCY_PARTIAL_BUILD: 1

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -67,13 +67,26 @@ jobs:
         run: >-
           echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
           && sudo sysctl -p
+      - name: Should run E2E?
+        id: should-run-e2e
+        run: >
+          # `grep -c` fails if list is empty (no e2e tests to run)
+
+          SHOULD_RUN_E2E=$(yarn nx print-affected --base=deployed/marmicode-next
+          \
+            | yarn json projects | grep -c e2e && echo true || echo false)
+          echo "::set-output name=should-run-e2e::$SHOULD_RUN_E2E"
       - name: All E2E
-        if: github.ref == 'refs/heads/main'
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          steps.should-run-e2e.outputs.should-run-e2e != false
         run: >-
           npx @percy/cli exec -- $(npm bin)/nx run-many --all --target=e2e
           --base=deployed/marmicode-next --browser=chrome
       - name: Affected E2E
-        if: github.ref != 'refs/heads/main'
+        if: >-
+          github.ref != 'refs/heads/main' &&
+          steps.should-run-e2e.outputs.should-run-e2e != false
         run: >-
           npx @percy/cli exec -- $(npm bin)/nx affected --target=e2e
           --base=deployed/marmicode-next --browser=chrome

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -93,7 +93,9 @@ jobs:
         env:
           PERCY_PARTIAL_BUILD: 1
       - name: Check Percy Review
-        if: steps.should-run-e2e.outputs.should-run-e2e != false
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          steps.should-run-e2e.outputs.should-run-e2e != false
         run: >-
           PERCY_TOKEN=$PERCY_FULL_TOKEN npx @percy/cli build:wait --project
           marmicode/marmicode --commit "${PR_HEAD_SHA:-$GITHUB_SHA}"

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -67,26 +67,13 @@ jobs:
         run: >-
           echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
           && sudo sysctl -p
-      - name: Should run E2E?
-        id: should-run-e2e
-        run: >
-          # `grep -c` fails if list is empty (no e2e tests to run)
-
-          SHOULD_RUN_E2E=$(yarn nx print-affected --base=deployed/marmicode-next
-          \
-            | yarn json projects | grep -c e2e && echo true || echo false)
-          echo "::set-output name=should-run-e2e::$SHOULD_RUN_E2E"
       - name: All E2E
-        if: >-
-          github.ref == 'refs/heads/main' &&
-          steps.should-run-e2e.outputs.should-run-e2e != false
+        if: github.ref == 'refs/heads/main'
         run: >-
           npx @percy/cli exec -- $(npm bin)/nx run-many --all --target=e2e
           --base=deployed/marmicode-next --browser=chrome
       - name: Affected E2E
-        if: >-
-          github.ref != 'refs/heads/main' &&
-          steps.should-run-e2e.outputs.should-run-e2e != false
+        if: github.ref != 'refs/heads/main'
         run: >-
           npx @percy/cli exec -- $(npm bin)/nx affected --target=e2e
           --base=deployed/marmicode-next --browser=chrome


### PR DESCRIPTION
percy build:wait will fail if there are changes no matter if they are approved or not,
there is no way to know if the build was approved with the CLI.
We would need to hack the HTTP API but it's useless because
Percy status check does the job.
