### PR TITLE
ci: 🤖 fix percy retry issue

### DIFF
--- a/.github/src/workflows/test-and-deploy.yml
+++ b/.github/src/workflows/test-and-deploy.yml
@@ -161,13 +161,13 @@ jobs:
       - *setup-node
       - *yarn-install
 
-      - name: Upload Percy Snapshots
+      - name: Upload Affected Percy Snapshots
         if: github.ref != 'refs/heads/main'
-        run: yarn nx affected --target=upload-percy-snapshots --parallel=1 --base=deployed/marmicode-next
+        run: yarn percy exec --partial -- nx affected --target=upload-percy-snapshots --parallel=1 --base=deployed/marmicode-next
 
       - name: Upload All Percy Snapshots
         if: github.ref == 'refs/heads/main'
-        run: yarn nx run-many --target=upload-percy-snapshots --parallel=1
+        run: yarn percy exec -- yarn nx run-many --target=upload-percy-snapshots --parallel=1
 
       - name: Finalize Percy
         run: yarn percy build:finalize

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -113,7 +113,13 @@ jobs:
           node-version: '18'
       - name: Install
         run: yarn install --immutable
+      - name: Affected Component Tests
+        if: github.ref != 'refs/heads/main'
+        run: >-
+          yarn nx affected --target=component-test --parallel 1
+          --base=deployed/marmicode-next
       - name: All Component Tests
+        if: github.ref == 'refs/heads/main'
         run: yarn nx run-many --target=component-test --parallel 1
       - name: Upload dist (Cypress videos / build output etc...) on failure
         uses: actions/upload-artifact@v2
@@ -145,7 +151,13 @@ jobs:
           node-version: '18'
       - name: Install
         run: yarn install --immutable
+      - name: Affected E2E
+        if: github.ref != 'refs/heads/main'
+        run: >-
+          yarn nx affected --target=e2e --parallel 1
+          --base=deployed/marmicode-next
       - name: All E2E
+        if: github.ref == 'refs/heads/main'
         run: yarn nx run-many --target=e2e --parallel 1
       - name: Upload dist (Cypress videos / build output etc...) on failure
         uses: actions/upload-artifact@v2
@@ -183,8 +195,17 @@ jobs:
           node-version: '18'
       - name: Install
         run: yarn install --immutable
+      - name: Upload Affected Percy Snapshots
+        if: github.ref != 'refs/heads/main'
+        run: >-
+          yarn percy exec --partial -- nx affected
+          --target=upload-percy-snapshots --parallel=1
+          --base=deployed/marmicode-next
       - name: Upload All Percy Snapshots
-        run: yarn nx run-many --target=upload-percy-snapshots --parallel=1
+        if: github.ref == 'refs/heads/main'
+        run: >-
+          yarn percy exec -- yarn nx run-many --target=upload-percy-snapshots
+          --parallel=1
       - name: Finalize Percy
         run: yarn percy build:finalize
       - name: Check Percy Review

--- a/tools/upload-percy-snapshots.sh
+++ b/tools/upload-percy-snapshots.sh
@@ -1,14 +1,7 @@
 #!/usr/bin/env sh
 
-COMMAND="yarn percy exec --parallel"
-
-# Add `--partial` option if we're running on a PR,
-# because we will be using `nx affected` so not all snapshots will be uploaded.
-if [ "$(git branch --show-current)" != "main" ];
-then
-  COMMAND="$COMMAND --partial"
-fi
+set -e
 
 PROJECT_PATH=$1
 
-$COMMAND -- ts-node -P tools/tsconfig.tools.json tools/upload-percy-snapshots.ts $PROJECT_PATH
+ts-node -P tools/tsconfig.tools.json tools/upload-percy-snapshots.ts $PROJECT_PATH


### PR DESCRIPTION
avoid percy --parallel which needs more setup
to allow retry using a random nonce.
by default, it is using the ci's run id so retrying
the same run will always fail.
