### PR TITLE
fix: 🐞 fix hreflang origin

### DIFF
--- a/apps/marmicode/src/app/app.config.ts
+++ b/apps/marmicode/src/app/app.config.ts
@@ -30,12 +30,14 @@ import {
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { provideRouterStore, routerReducer } from '@ngrx/router-store';
 import { provideStore } from '@ngrx/store';
+import { provideSiteConfig } from '@marmicode/shared/core';
 import { environment } from '../environments/environment';
 import { routes } from './app.routes';
 import { provideUpdateEffects } from './update/update.effects';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideSiteConfig({ origin: environment.origin }),
     /* HACK: This is a workaround to fix tracking.
      * Cf. https://github.com/angular/angularfire/issues/3633#issuecomment-2817498717 */
     importProvidersFrom(AnalyticsModule),

--- a/apps/marmicode/src/environments/environment.next.ts
+++ b/apps/marmicode/src/environments/environment.next.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  origin: 'https://marmicode-next.web.app',
   firebase: {
     apiKey: 'AIzaSyAqFA9ihQdPuX4VwX46RRTEbVOXnYB76gI',
     authDomain: 'marmicode-next.firebaseapp.com',

--- a/apps/marmicode/src/environments/environment.prod.ts
+++ b/apps/marmicode/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  origin: 'https://marmicode.io',
   firebase: {
     apiKey: 'AIzaSyDBPhimUCE5lMSQCSYQfvSZLLFmu7mi2DM',
     authDomain: 'marmicode.firebaseapp.com',

--- a/apps/marmicode/src/environments/environment.ts
+++ b/apps/marmicode/src/environments/environment.ts
@@ -7,6 +7,7 @@ import { environment as environmentNext } from './environment.next';
 export const environment = {
   production: false,
   firebase: environmentNext.firebase,
+  origin: null,
 };
 
 /*

--- a/libs/shared/core/index.ts
+++ b/libs/shared/core/index.ts
@@ -1,0 +1,2 @@
+export { provideSiteConfig } from './provide-site-config';
+export { SiteConfig } from './site-config';

--- a/libs/shared/core/provide-site-config.ts
+++ b/libs/shared/core/provide-site-config.ts
@@ -1,0 +1,6 @@
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import { SiteConfig } from './site-config';
+
+export function provideSiteConfig(config: SiteConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([{ provide: SiteConfig, useValue: config }]);
+}

--- a/libs/shared/core/site-config.ts
+++ b/libs/shared/core/site-config.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export abstract class SiteConfig {
+  /**
+   * The origin of the site.
+   * This can't be dynamic due to SSG.
+   * When set to `null` (mainly for local development), the origin will
+   * be computed from the `PlatformLocation` service.
+   */
+  abstract readonly origin: string | null;
+}

--- a/libs/shared/infra/index.ts
+++ b/libs/shared/infra/index.ts
@@ -1,0 +1,1 @@
+export { PlatformInfo } from './platform-info';

--- a/libs/shared/infra/platform-info.ts
+++ b/libs/shared/infra/platform-info.ts
@@ -1,0 +1,23 @@
+import { PlatformLocation } from '@angular/common';
+import { Injectable, inject } from '@angular/core';
+import { SiteConfig } from '@marmicode/shared/core';
+
+@Injectable({ providedIn: 'root' })
+export class PlatformInfo {
+  private _siteConfig = inject(SiteConfig);
+  private _platformLocation = inject(PlatformLocation);
+
+  /**
+   * Returns the origin of the site.
+   * If the origin is not set in the `SiteConfig`, the origin will be computed from the `PlatformLocation` service.
+   * The reason for this is that the origin can't be dynamic due to SSG.
+   */
+  getOrigin(): string {
+    const origin = this._siteConfig.origin;
+    if (origin != null) {
+      return origin;
+    }
+    const { protocol, hostname, port } = this._platformLocation;
+    return `${protocol}//${hostname}:${port}`;
+  }
+}

--- a/libs/shared/ui/lib/page.component.spec.ts
+++ b/libs/shared/ui/lib/page.component.spec.ts
@@ -3,6 +3,7 @@ import {
   MockPlatformLocationConfig,
 } from '@angular/common/testing';
 import { TestBed } from '@angular/core/testing';
+import { provideSiteConfig } from '@marmicode/shared/core';
 import { MetaDefinition } from '@angular/platform-browser';
 import { describe, expect, it } from 'vitest';
 import { MetaFake, provideMetaFake } from '../testing/meta.fake';
@@ -120,6 +121,44 @@ describe('PageComponent', () => {
       ]);
   });
 
+  it('uses PlatformLocation for URLs when site origin is null', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideSiteConfig({ origin: null }),
+        {
+          provide: MOCK_PLATFORM_LOCATION_CONFIG,
+          useValue: {
+            startUrl: 'https://marmicode.io',
+          } satisfies MockPlatformLocationConfig,
+        },
+        provideMetaFake(),
+        provideTitleFake(),
+        provideHtmlAdapterFake(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(PageComponent);
+    fixture.componentRef.setInput('info', {
+      alternates: [
+        { path: '/workshops/test-angular-pragmatique', language: 'fr' },
+        { path: '/workshops/pragmatic-angular-testing', language: 'en' },
+      ],
+    });
+
+    const htmlAdapterFake = TestBed.inject(HtmlAdapterFake);
+
+    await expect
+      .poll(() => {
+        const link = htmlAdapterFake
+          .getLinkTags()
+          .find((e) => e.rel === 'canonical');
+        return link?.href;
+      })
+      .toBe('https://marmicode.io/workshops/pragmatic-angular-testing');
+
+    fixture.destroy();
+  });
+
   it('removes canonical and alternate links when component is destroyed', async () => {
     const { destroyOnceStable, htmlAdapterFake, setPageInfo } =
       await renderComponent();
@@ -222,12 +261,7 @@ describe('PageComponent', () => {
 async function renderComponent() {
   TestBed.configureTestingModule({
     providers: [
-      {
-        provide: MOCK_PLATFORM_LOCATION_CONFIG,
-        useValue: {
-          startUrl: 'https://marmicode.io',
-        } satisfies MockPlatformLocationConfig,
-      },
+      provideSiteConfig({ origin: 'https://marmicode.io' }),
       provideMetaFake(),
       provideTitleFake(),
       provideHtmlAdapterFake(),

--- a/libs/shared/ui/lib/page.component.ts
+++ b/libs/shared/ui/lib/page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, PlatformLocation } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -8,6 +8,7 @@ import {
   input,
 } from '@angular/core';
 import { Meta, MetaDefinition, Title } from '@angular/platform-browser';
+import { PlatformInfo } from '@marmicode/shared/infra';
 import { HtmlAdapter } from './html-adapter';
 
 export interface BasicPageInfo {
@@ -62,7 +63,7 @@ export class PageComponent {
   private _titleService = inject(Title);
   private _defaultLanguage = 'en';
   private _defaultTitle = 'Marmicode';
-  private _platformLocation = inject(PlatformLocation);
+  private _platformInfo = inject(PlatformInfo);
 
   constructor() {
     effect((onCleanup) => {
@@ -160,8 +161,7 @@ export class PageComponent {
   }
 
   private _pathToUrl(path: string) {
-    const { protocol, hostname, port } = this._platformLocation;
-    return new URL(path, `${protocol}//${hostname}:${port}`).toString();
+    return new URL(path, this._platformInfo.getOrigin()).href;
   }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,8 @@
       "@marmicode/services/feature-presentation": [
         "libs/services/feature-presentation/index.ts"
       ],
+      "@marmicode/shared/core": ["libs/shared/core/index.ts"],
+      "@marmicode/shared/infra": ["libs/shared/infra/index.ts"],
       "@marmicode/shared/router-helpers": [
         "libs/shared/router-helpers/index.ts"
       ],


### PR DESCRIPTION
hreflang is known to be better supported when provided with full URLs.
As we are using SSG, computing origin dynamically produces invalid origin
http://ng-localhost
