### PR TITLE
Add debug to Pragmatic Angular and React testing workshop titles

### DIFF
--- a/libs/workshop/infra/workshops/pragmatic-angular-testing/pragmatic-angular-testing.en.ts
+++ b/libs/workshop/infra/workshops/pragmatic-angular-testing/pragmatic-angular-testing.en.ts
@@ -4,7 +4,7 @@ import thumbnailUri from './pragmatic-angular-testing-thumbnail.webp';
 
 export const pragmaticAngularTestingFullCourseEn = createWorkshop({
   id: 'pragmatic-angular-testing',
-  title: 'Pragmatic Angular Testing Workshop',
+  title: 'Pragmatic Angular Testing Debug Workshop',
   shortTitle: 'Pragmatic Angular Testing',
   type: 'full',
   subheading: `Three days to turn testing chaos into a well-seasoned strategy.

--- a/libs/workshop/infra/workshops/pragmatic-react-testing/pragmatic-react-testing.en.ts
+++ b/libs/workshop/infra/workshops/pragmatic-react-testing/pragmatic-react-testing.en.ts
@@ -4,7 +4,7 @@ import thumbnailUri from './pragmatic-react-testing-thumbnail.webp';
 
 export const pragmaticReactTestingFullCourseEn = createWorkshop({
   id: 'pragmatic-react-testing',
-  title: 'Pragmatic React Testing Workshop',
+  title: 'Pragmatic React Testing Debug Workshop',
   shortTitle: 'Pragmatic React Testing',
   type: 'full',
   subheading: `Three days to turn testing chaos into a well-seasoned strategy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the English workshop `title` fields:

- **Pragmatic Angular Testing:** "Pragmatic Angular Testing Workshop" → "Pragmatic Angular Testing Debug Workshop"
- **Pragmatic React Testing:** "Pragmatic React Testing Workshop" → "Pragmatic React Testing Debug Workshop"

`shortTitle` values are unchanged, so workshop list headings and existing e2e assertions remain valid.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f7da116-7840-4444-8eb6-702132cf9d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f7da116-7840-4444-8eb6-702132cf9d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

